### PR TITLE
Feature new transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A modern, extensible, and type-safe Python library for parsing, transforming, an
 ## Features
 
 - **Type-Safe Parsing**: Validates HAR files using Pydantic models, catching errors early.
-- **Transformers**: Apply built-in or custom transformations to each HAR entry (e.g., flattening, normalization).
+- **Transformers**: Apply built-in or custom transformations to each HAR entry (e.g., stringifying, normalization).
 - **Normalization**: Ensures all numeric fields (sizes, timings) are non-negative, so you can safely sum, aggregate, and analyze data without errors from negative values. This is crucial for analytics and reporting.
 - **Deterministic & Random IDs**: Generate unique or deterministic IDs for each entry. Deterministic IDs ensure that the same request always gets the same ID—useful for deduplication, comparison, and building analytics pipelines.
 - **Extensible**: Register your own entry models to support browser-specific or proprietary HAR extensions (e.g., Chrome DevTools, Safari).
@@ -25,12 +25,12 @@ pip install hario-core
 ## Quickstart
 
 ```python
-from hario_core import parse, Pipeline, by_field, normalize_sizes, flatten
+from hario_core import parse, Pipeline, by_field, normalize_sizes, stringify
 
-# Build a processing pipeline: deterministic ID, normalization, flattening
+# Build a processing pipeline: deterministic ID, normalization, stringifying
 pipeline = Pipeline(
     id_fn=by_field(["request.url", "startedDateTime"]),
-    transformers=[normalize_sizes(), flatten()],
+    transformers=[normalize_sizes(), stringify()],
 )
 
 # Parse your HAR file (from path, bytes, or file-like object)

--- a/docs/api.md
+++ b/docs/api.md
@@ -141,13 +141,13 @@ id_fn = uuid()
 
 Transformers are functions that mutate or normalize HAR entry data for storage or analysis.
 
-### `flatten`
+### `stringify`
 
-Flattens nested structures in a HAR entry to a single level, stringifying deep or large fields (useful for DB storage).
+Stringifies nested structures in a HAR entry to a single level, stringifying deep or large fields (useful for DB storage).
 
 **Signature:**
 ```python
-def flatten(
+def stringify(
     max_depth: int = 3,
     size_limit: int = 32_000,
 ) -> Transformer
@@ -157,7 +157,7 @@ def flatten(
 
 **Example:**
 ```python
-flat_entry = flatten()(entry)
+string_entry = stringify()(entry)
 ```
 
 ### `normalize_sizes`
@@ -207,11 +207,11 @@ class Pipeline:
 ## Example: Full Pipeline
 
 ```python
-from hario_core import Pipeline, by_field, flatten, normalize_sizes, parse
+from hario_core import Pipeline, by_field, stringify, normalize_sizes, parse
 
 pipeline = Pipeline(
     id_fn=by_field(["request.url", "startedDateTime"]),
-    transformers=[flatten(), normalize_sizes()],
+    transformers=[stringify(), normalize_sizes()],
 )
 
 model = parse("example.har")

--- a/docs/api.md
+++ b/docs/api.md
@@ -176,12 +176,13 @@ def flatten(
 
 **Example:**
 ```python
-import hashlib
-flat_entry = flatten(
-    array_handler=lambda arr, path: hashlib.md5(str(arr).encode()).hexdigest()
-    if path == 'initiator.stack.callFrames' else str(arr)
-)(entry)
-# flat_entry['initiator.stack.callFrames'] == 'e99a18c428cb38d5f260853678922e03' (example hash)
+def header_handler(arr, path):
+    # Each header becomes a separate key by name
+    return {f"{path}.{item['name']}": item["value"] for item in arr if isinstance(item, dict) and "name" in item and "value" in item}
+
+flat_entry = flatten(array_handler=header_handler)(entry)
+# flat_entry['request.headers.user-agent'] == 'Mozilla/5.0 ...'
+# flat_entry['request.headers.:authority'] == 'test.test'
 ```
 
 **Difference from stringify:**

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ Hario Core is a modern, extensible, and type-safe Python library for parsing, tr
 
 - **Parser**: Use `parse()` to load and validate HAR files into Pydantic models (`HarLog`, `Entry`).
 - **Pipeline**: The `Pipeline` class lets you process HAR logs, assign IDs, and apply transformations in a composable way.
-- **Transformers**: Built-in and custom functions (like `stringify`, `normalize_sizes`, `normalize_timings`) to mutate or normalize HAR entries for storage or analytics.
+- **Transformers**: Built-in and custom functions (like `stringify`, `flatten`, `normalize_sizes`, `normalize_timings`) to mutate or normalize HAR entries for storage or analytics.
 - **Utils**: Utilities for ID generation (`by_field`, `uuid`), model registration (`register_entry_model`), and more.
 
 See the [API Reference](api.md) for detailed usage, signatures, and extension patterns.
@@ -14,7 +14,7 @@ See the [API Reference](api.md) for detailed usage, signatures, and extension pa
 ## Key Features
 
 - **Type-Safe Parsing**: Validates HAR files using Pydantic models, catching errors early.
-- **Transformers**: Apply built-in or custom transformations to each HAR entry (e.g., stringifying, normalization).
+- **Transformers**: Apply built-in or custom transformations to each HAR entry (e.g., stringifying, flattening, normalization).
 - **Normalization**: Ensures all numeric fields (sizes, timings) are non-negative, so you can safely sum, aggregate, and analyze data without errors from negative values. This is crucial for analytics and reporting.
 - **Deterministic & Random IDs**: Generate unique or deterministic IDs for each entry. Deterministic IDs ensure that the same request always gets the same ID—useful for deduplication, comparison, and building analytics pipelines.
 - **Extensible**: Register your own entry models to support browser-specific or proprietary HAR extensions (e.g., Chrome DevTools, Safari).
@@ -57,11 +57,11 @@ assert isinstance(entry, DevToolsEntry)  # True for DevTools entries
 ## Example: Full Pipeline
 
 ```python
-from hario_core import parse, Pipeline, by_field, stringify, normalize_sizes
+from hario_core import parse, Pipeline, by_field, stringify, flatten, normalize_sizes
 
 pipeline = Pipeline(
     id_fn=by_field(["request.url", "startedDateTime"]),
-    transformers=[stringify(), normalize_sizes()],
+    transformers=[stringify(), flatten(), normalize_sizes()],
 )
 
 model = parse("example.har")

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ Hario Core is a modern, extensible, and type-safe Python library for parsing, tr
 
 - **Parser**: Use `parse()` to load and validate HAR files into Pydantic models (`HarLog`, `Entry`).
 - **Pipeline**: The `Pipeline` class lets you process HAR logs, assign IDs, and apply transformations in a composable way.
-- **Transformers**: Built-in and custom functions (like `flatten`, `normalize_sizes`, `normalize_timings`) to mutate or normalize HAR entries for storage or analytics.
+- **Transformers**: Built-in and custom functions (like `stringify`, `normalize_sizes`, `normalize_timings`) to mutate or normalize HAR entries for storage or analytics.
 - **Utils**: Utilities for ID generation (`by_field`, `uuid`), model registration (`register_entry_model`), and more.
 
 See the [API Reference](api.md) for detailed usage, signatures, and extension patterns.
@@ -14,7 +14,7 @@ See the [API Reference](api.md) for detailed usage, signatures, and extension pa
 ## Key Features
 
 - **Type-Safe Parsing**: Validates HAR files using Pydantic models, catching errors early.
-- **Transformers**: Apply built-in or custom transformations to each HAR entry (e.g., flattening, normalization).
+- **Transformers**: Apply built-in or custom transformations to each HAR entry (e.g., stringifying, normalization).
 - **Normalization**: Ensures all numeric fields (sizes, timings) are non-negative, so you can safely sum, aggregate, and analyze data without errors from negative values. This is crucial for analytics and reporting.
 - **Deterministic & Random IDs**: Generate unique or deterministic IDs for each entry. Deterministic IDs ensure that the same request always gets the same ID—useful for deduplication, comparison, and building analytics pipelines.
 - **Extensible**: Register your own entry models to support browser-specific or proprietary HAR extensions (e.g., Chrome DevTools, Safari).
@@ -57,11 +57,11 @@ assert isinstance(entry, DevToolsEntry)  # True for DevTools entries
 ## Example: Full Pipeline
 
 ```python
-from hario_core import parse, Pipeline, by_field, flatten, normalize_sizes
+from hario_core import parse, Pipeline, by_field, stringify, normalize_sizes
 
 pipeline = Pipeline(
     id_fn=by_field(["request.url", "startedDateTime"]),
-    transformers=[flatten(), normalize_sizes()],
+    transformers=[stringify(), normalize_sizes()],
 )
 
 model = parse("example.har")

--- a/src/hario_core/__init__.py
+++ b/src/hario_core/__init__.py
@@ -38,7 +38,7 @@ from hario_core.models.har_1_2 import (
 )
 from hario_core.pipeline import Pipeline
 from hario_core.utils.id import by_field, uuid
-from hario_core.utils.transform import flatten, normalize_sizes, normalize_timings
+from hario_core.utils.transform import normalize_sizes, normalize_timings, stringify
 
 __all__ = [
     # har_parser
@@ -51,7 +51,7 @@ __all__ = [
     "by_field",
     "uuid",
     # transform utils
-    "flatten",
+    "stringify",
     "normalize_sizes",
     "normalize_timings",
     # interfaces

--- a/src/hario_core/utils/transform.py
+++ b/src/hario_core/utils/transform.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Protocol
 from hario_core.models.har_1_2 import Entry
 
 __all__ = [
-    "flatten",
+    "stringify",
     "normalize_sizes",
     "normalize_timings",
 ]
@@ -19,7 +19,7 @@ class Transformer(Protocol):
     def __call__(self, entry: Entry) -> Dict[str, Any]: ...
 
 
-def flatten(max_depth: int = 3, size_limit: int = 32_000) -> Transformer:
+def stringify(max_depth: int = 3, size_limit: int = 32_000) -> Transformer:
     """
     Flattens the HAR data into a single level.
     This is useful for storing HAR data in a database.


### PR DESCRIPTION
## What’s changed

- **feat:** Introduced a new `flatten` transformer that fully flattens nested HAR entries into a flat dict, with customizable key separator and flexible array handling via `array_handler`.
- **refactor:** The old `flatten` (which stringifies deep/large structures) is now called `stringify`.
- **test:** Added tests for the new `flatten` (custom array handlers, separator, path support).
- **faq:** Added a practical FAQ to the README on why to use hario-core over plain json + pandas.

## Why

- The new `flatten` is designed for advanced analytics and BI: you can now aggregate, hash, or count arrays by key directly in your pipeline.
- `stringify` remains for simple stringification of nested structures.

## Breaking changes

- The previous `flatten` is now `stringify`. The new `flatten` has different behavior—please update your code accordingly.
